### PR TITLE
Relex rule for Mean and ResizeBilinear

### DIFF
--- a/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
+++ b/tensorflow/lite/delegates/nnapi/nnapi_delegate.cc
@@ -1682,6 +1682,7 @@ bool NNAPIDelegateKernel::Validate(
       }
       auto builtin =
           reinterpret_cast<TfLiteResizeBilinearParams*>(node->builtin_data);
+      #if defined __ANDROID__
       if (android_sdk_version <= kMinSdkVersionForNNAPI12) {
         Expect(!builtin->align_corners,
                NNAPIValidationFailureType::kUnsupportedOperandValue,
@@ -1690,6 +1691,7 @@ bool NNAPIDelegateKernel::Validate(
                NNAPIValidationFailureType::kUnsupportedOperandValue,
                "NNAPI does not support half_pixel_centers == true.", &val_ctx);
       }
+      #endif
       if (android_sdk_version < kMinSdkVersionForNNAPI12) {
         Expect(input.type == kTfLiteFloat32,
                NNAPIValidationFailureType::kUnsupportedInputType,
@@ -2118,6 +2120,7 @@ bool NNAPIDelegateKernel::Validate(
              "NNAPI does not support generating a scalar as output for MEAN.",
              &val_ctx);
 
+    #if defined __ANDROID__
       auto input_param = context->tensors[node->inputs->data[0]].params;
       auto output_param = context->tensors[node->outputs->data[0]].params;
       Expect(input_param.scale == output_param.scale &&
@@ -2126,6 +2129,7 @@ bool NNAPIDelegateKernel::Validate(
              "NNAPI requires that the input and output have the same "
              "quantization parameters.",
              &val_ctx);
+    #endif
     } break;
     case kTfLiteBuiltinEmbeddingLookup: {
       ExpectOpVersion(version, 1, &val_ctx);


### PR DESCRIPTION
* NNAPI requires MEAN operation input and output has same parameter,
  but it is not required by NNRT backend. Relax this for Linux testing.

* Relax ResizeBilinear operation requirement for
  align_corners and half_pixel_centers for NNAPI delegate
  on Linux.

Signed-off-by: zongwu.yang <Zongwu.Yang@verisilicon.com>