### PR TITLE
[NNRT-890] Update label_image with cache - Android/Linux v2.3.1

### DIFF
--- a/tensorflow/lite/examples/label_image/README.md
+++ b/tensorflow/lite/examples/label_image/README.md
@@ -146,6 +146,7 @@ Android --input_mean, -b: input mean --input_std, -s: input standard deviation
 -m: model_name.tflite --profiling, -p: [0|1], profiling or not --num_results,
 -r: number of results to show --threads, -t: number of threads --verbose, -v:
 [0|1] print more information --warmup_runs, -w: number of warmup runs
---xnnpack_delegate, -x [0:1]: xnnpack delegate`
+--xnnpack_delegate, -x [0:1]: xnnpack delegate --cache_dir, -z: location of model
+cache, --model_token, -o: identification of model cache `
 
 See the `label_image.cc` source code for other command line options.

--- a/tensorflow/lite/examples/label_image/label_image.h
+++ b/tensorflow/lite/examples/label_image/label_image.h
@@ -43,6 +43,8 @@ struct Settings {
   int number_of_results = 5;
   int max_profiling_buffer_entries = 1024;
   int number_of_warmup_runs = 2;
+  string cache_dir;
+  string model_token;
 };
 
 }  // namespace label_image


### PR DESCRIPTION
 The example of  label_image:
./label_image -i *.bmp  -m *.tflite  -a 1 -l  *.txt -z * -o *
-z: the string of cache model dir
-o: the string of cache model token
 