### PR TITLE
Support Makefile building for label_image with vx-delegate

### DIFF
--- a/tensorflow/lite/tools/make/Makefile
+++ b/tensorflow/lite/tools/make/Makefile
@@ -59,7 +59,7 @@ LIBS := \
 # generate things like the protobuf compiler that require that), so all of
 # these settings are for the target compiler.
 CFLAGS := -O3 -DNDEBUG -fPIC $(EXTRA_CFLAGS)
-CXXFLAGS := $(CFLAGS) --std=c++11 $(EXTRA_CXXFLAGS)
+CXXFLAGS := $(CFLAGS) --std=c++14 $(EXTRA_CXXFLAGS)
 LDOPTS := -L/usr/local/lib
 ARFLAGS := -r
 TARGET_TOOLCHAIN_PREFIX :=
@@ -213,6 +213,25 @@ else
 	CORE_CC_ALL_SRCS += tensorflow/lite/nnapi/nnapi_implementation_disabled.cc
 endif
 
+# Support VX_DELEGATE
+BUILD_WITH_VX_DELEGATE ?= true
+ifeq ($(BUILD_WITH_VX_DELEGATE), true)
+	ifeq ($(TIM_VX_DIR), )
+        $(error "Please set your TIM_VX_DIR")
+	endif
+	TIM_VX_DIR = /home/yzw/code/mygithub/TIM-VX/
+	INCLUDES += -I./tensorflow/lite/delegates/vx-delegate
+	INCLUDES += -I./tensorflow/core/platform
+	INCLUDES += -I./tensorflow/core/platform/default
+	INCLUDES += -I$(TIM_VX_DIR)/include
+	CORE_CC_ALL_SRCS += tensorflow/lite/delegates/vx-delegate/delegate_main.cc
+	CORE_CC_ALL_SRCS += tensorflow/lite/delegates/vx-delegate/op_map.cc
+	CORE_CC_ALL_SRCS += tensorflow/core/platform/default/logging.cc
+	CORE_CC_ALL_SRCS += tensorflow/core/platform/default/env_time.cc
+	LIBS += -L$(TIM_VX_DIR)/build/src/tim/vx -l tim-vx
+	LIBS += -L$(TIM_VX_DIR)/prebuilt-sdk/x86_64_linux/lib -lEmulator -lvdtproxy -lCLC -lGAL -lOpenVX -lOpenVXU -lVSC -lArchModelSw -lNNArchPerf
+endif
+
 ifeq ($(TARGET),ios)
 	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/minimal_logging_android.cc
 	CORE_CC_EXCLUDE_SRCS += tensorflow/lite/minimal_logging_default.cc
@@ -323,7 +342,7 @@ $(OBJDIR)%.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 # The target that's compiled if there's no command-line arguments.
-all: $(LIB_PATH)  $(MINIMAL_BINARY) $(BENCHMARK_BINARY) $(BENCHMARK_PERF_OPTIONS_BINARY)
+all: $(LIB_PATH)  $(MINIMAL_BINARY) $(BENCHMARK_BINARY) $(BENCHMARK_PERF_OPTIONS_BINARY) $(LABEL_IMAGE_BINARY)
 
 # The target that's compiled for micro-controllers
 micro: $(LIB_PATH)


### PR DESCRIPTION
Usage:

Update build_lib.sh under same dir of Makefile to define define your
TIM_VX_DIR.

``
eg.  make TIM_VX_DIR="/home/code/TIM-VX" -j 8 -C
"${TENSORFLOW_DIR}" -f tensorflow/lite/tools/make/Makefile $@

Signed-off-by: Zongwu.Yang <Zongwu.Yang@verisilicon.com>